### PR TITLE
🔧 (devenv) Change systems `default-linux` -> `x86_64-linux`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,16 +46,16 @@
     "systems": {
       "flake": false,
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1680978846,
+        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "x86_64-linux",
+        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "x86_64-linux",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
     };
 
     systems = {
-      url = "github:nix-systems/default-linux";
+      url = "github:nix-systems/x86_64-linux";
       flake = false;
     };
   };


### PR DESCRIPTION
### 📖 Overview

Changed supported systems from default-linux to x86_64-linux.

### 🔗 Linked issue

#6

### 📌 Additional comments

None
