### PR TITLE
🚑 (devenv) Fix yamllint to work properly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
             yamllint = {
               enable = true;
               description = "Detects anti-patterns in YAML files.";
-              entry = "{pkgs.yamllint}/bin/yamllint -sd \"{rules: {line-length: {max: 120}, document-start: disable}}\"";
+              entry = "${pkgs.yamllint}/bin/yamllint -sd \"{rules: {line-length: {max: 120}, document-start: disable}}\"";
               after = [ "prettier" ];
             };
           };


### PR DESCRIPTION
### 📖 Overview

Fixed a mistake in `flake.nix` so that yamllint works properly.

Test log:

```
$ touch foo.yaml

$ git add foo.yaml

$ pre-commit run
nixfmt-tree..........................................(no files to check)Skipped
deadnix..............................................(no files to check)Skipped
prettier.................................................................Passed
markdownlint.........................................(no files to check)Skipped
statix...............................................(no files to check)Skipped
yamllint.................................................................Passed
```

### 🔗 Linked issue

#18

### 📌 Additional comments

None
